### PR TITLE
!HOTFIX: ios에서 풀이 시간 입력 시 숫자 키패드 안 나오는 버그 수정

### DIFF
--- a/src/containers/Solvetime/SolvetimeContainer.tsx
+++ b/src/containers/Solvetime/SolvetimeContainer.tsx
@@ -40,6 +40,7 @@ const SolvetimeContainer = ({ moId }: SolvetimeContainerProps) => {
 			<div className="w-full h-96 flex gap-2 justify-center items-center">
 				<input
 					type="number"
+					pattern="\d*"
 					value={hour}
 					onChange={handleHourChange}
 					className="rounded-lg w-12 h-12 border border-orange-500 text-orange-500 text-2xl text-center focus:outline-none"
@@ -47,6 +48,7 @@ const SolvetimeContainer = ({ moId }: SolvetimeContainerProps) => {
 				<div className="text-xl mr-4">시간</div>
 				<input
 					type="number"
+					pattern="\d*"
 					value={minute}
 					onChange={handleMinuteChange}
 					className="rounded-lg w-12 h-12 border border-orange-500 text-orange-500 text-2xl text-center focus:outline-none"


### PR DESCRIPTION
pattern="\d*" 추가 해야 ios에서도 숫자 키패드 나옴